### PR TITLE
Change the schema to include IDs

### DIFF
--- a/nephthys/actions/assign_tag.py
+++ b/nephthys/actions/assign_tag.py
@@ -24,7 +24,7 @@ async def assign_tag_callback(
     channel_id = body["channel"]["id"]
     ts = body["message"]["ts"]
 
-    user = await env.db.user.find_unique(where={"id": user_id})
+    user = await env.db.user.find_unique(where={"slackId": user_id})
     if not user or not user.helper:
         await client.chat_postEphemeral(
             channel=channel_id,

--- a/nephthys/actions/create_tag.py
+++ b/nephthys/actions/create_tag.py
@@ -14,7 +14,7 @@ async def create_tag_view_callback(ack: AsyncAck, body: dict, client: AsyncWebCl
     await ack()
     user_id = body["user"]["id"]
 
-    user = await env.db.user.find_unique(where={"id": user_id})
+    user = await env.db.user.find_unique(where={"slackId": user_id})
     if not user or not user.admin:
         await send_heartbeat(f"Attempted to create tag by non-admin user <@{user_id}>")
         return
@@ -33,7 +33,7 @@ async def create_tag_btn_callback(ack: AsyncAck, body: dict, client: AsyncWebCli
     user_id = body["user"]["id"]
     trigger_id = body["trigger_id"]
 
-    user = await env.db.user.find_unique(where={"id": user_id})
+    user = await env.db.user.find_unique(where={"slackId": user_id})
     if not user or not user.admin:
         await send_heartbeat(
             f"Attempted to open create tag modal by non-admin user <@{user_id}>"

--- a/nephthys/commands/dm_magic_link.py
+++ b/nephthys/commands/dm_magic_link.py
@@ -16,7 +16,7 @@ async def dm_magic_link_cmd_callback(
     await ack()
     logging.info(f"Received command: {command}")
     user_id = body["user_id"]
-    user = await env.db.user.find_unique(where={"id": user_id})
+    user = await env.db.user.find_unique(where={"slackId": user_id})
     if not user or not user.helper:
         await client.chat_postEphemeral(
             channel=body["channel_id"],

--- a/nephthys/events/app_home_opened.py
+++ b/nephthys/events/app_home_opened.py
@@ -23,7 +23,7 @@ async def open_app_home(home_type: str, client: AsyncWebClient, user_id: str):
     try:
         await client.views_publish(view=get_loading_view(), user_id=user_id)
 
-        user = await env.db.user.find_unique(where={"id": user_id})
+        user = await env.db.user.find_unique(where={"slackId": user_id})
 
         if not user:
             user_info = await client.users_info(user=user_id) or {}

--- a/nephthys/events/message.py
+++ b/nephthys/events/message.py
@@ -25,9 +25,9 @@ async def on_message(event: Dict[str, Any], client: AsyncWebClient):
 
     thread_url = f"https://hackclub.slack.com/archives/{env.slack_help_channel}/p{event['ts'].replace('.', '')}"
 
-    db_user = await env.db.user.find_first(where={"id": user})
+    db_user = await env.db.user.find_first(where={"slackId": user})
     if db_user:
-        past_tickets = await env.db.ticket.count(where={"openedById": user})
+        past_tickets = await env.db.ticket.count(where={"openedById": db_user.id})
     else:
         past_tickets = 0
         user_info = await client.users_info(user=user) or {}
@@ -41,11 +41,11 @@ async def on_message(event: Dict[str, Any], client: AsyncWebClient):
             )
         db_user = await env.db.user.upsert(
             where={
-                "id": user,
+                "slackId": user,
             },
             data={
-                "create": {"id": user, "username": username},
-                "update": {"id": user, "username": username},
+                "create": {"slackId": user, "username": username},
+                "update": {"slackId": user, "username": username},
             },
         )
 
@@ -95,7 +95,7 @@ async def on_message(event: Dict[str, Any], client: AsyncWebClient):
             "description": text,
             "msgTs": event["ts"],
             "ticketTs": ticket["ts"],
-            "openedBy": {"connect": {"id": user}},
+            "openedBy": {"connect": {"id": db_user.id}},
         },
     )
 

--- a/nephthys/tasks/update_helpers.py
+++ b/nephthys/tasks/update_helpers.py
@@ -17,19 +17,19 @@ async def update_helpers():
 
     # unset helpers not in the team
     await env.db.user.update_many(
-        where={"helper": True, "id": {"not_in": team_ids}},
+        where={"helper": True, "slackId": {"not_in": team_ids}},
         data={"helper": False},
     )
 
     # update existing users in the db
     await env.db.user.update_many(
-        where={"id": {"in": team_ids}},
+        where={"slackId": {"in": team_ids}},
         data={"helper": True},
     )
 
     # create new users not in the db
-    existing_users_in_db = await env.db.user.find_many(where={"id": {"in": team_ids}})
-    existing_user_ids_in_db = {user.id for user in existing_users_in_db}
+    existing_users_in_db = await env.db.user.find_many(where={"slackId": {"in": team_ids}})
+    existing_user_ids_in_db = {user.slackId for user in existing_users_in_db}
 
     new_member_data_to_create = []
     for member_id in team_ids:
@@ -41,7 +41,7 @@ async def update_helpers():
             logging.info(f"User info for {member_id}: {user_info}")
             new_member_data_to_create.append(
                 {
-                    "id": member_id,
+                    "slackId": member_id,
                     "helper": True,
                     "username": user_info.get("user", {}).get("name"),
                 }

--- a/nephthys/utils/permissions.py
+++ b/nephthys/utils/permissions.py
@@ -1,12 +1,12 @@
 from nephthys.utils.env import env
 
 
-async def can_resolve(user_id: str, ts: str) -> bool:
+async def can_resolve(user_id: int, ts: str) -> bool:
     """
     Check if the user has permission to resolve tickets.
 
     Args:
-        user_id (str): The ID of the user to check permissions for.
+        user_id (str): The database ID of the user to check permissions for.
         ts (str): The timestamp of the ticket message to check.
 
     Returns:

--- a/nephthys/views/home/tags.py
+++ b/nephthys/views/home/tags.py
@@ -29,7 +29,16 @@ async def get_manage_tags_view(user: User) -> dict:
             f"Tag {tag.name} has {len(tag.userSubscriptions) if tag.userSubscriptions else 0} subscriptions"
         )
         if tag.userSubscriptions:
-            subs = [user.userId for user in tag.userSubscriptions]
+            # Yes, there's a better way to do this.
+            # No, I don't care.
+            
+            subIds = [user.userId for user in tag.userSubscriptions]
+            
+            subUsers = await env.db.user.find_many(
+                where={"id": {"in": subIds}}
+            )
+            
+            subs = [user.slackId for user in subUsers]
         else:
             subs = []
         stringified_subs = [f"<@{user}>" for user in subs]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,8 @@ enum TicketStatus {
 }
 
 model User {
-  id       String  @id @unique
+  id       Int     @id @unique @default(autoincrement())
+  slackId  String  @unique
   username String? @unique
   admin    Boolean @default(false)
 
@@ -31,7 +32,7 @@ model User {
 }
 
 model Ticket {
-  id          String       @id @unique @default(cuid())
+  id          Int          @id @unique @default(autoincrement())
   title       String
   description String
   status      TicketStatus @default(OPEN)
@@ -40,14 +41,14 @@ model Ticket {
   ticketTs String @unique
 
   openedBy   User   @relation("OpenedTickets", fields: [openedById], references: [id])
-  openedById String
+  openedById Int
 
   closedBy   User?     @relation("ClosedTickets", fields: [closedById], references: [id])
-  closedById String?
+  closedById Int?
   closedAt   DateTime?
 
   assignedTo   User?   @relation("AssignedTickets", fields: [assignedToId], references: [id])
-  assignedToId String?
+  assignedToId Int?
 
   tagsOnTickets TagsOnTickets[]
 
@@ -55,7 +56,7 @@ model Ticket {
 }
 
 model Tag {
-  id   String @id @unique @default(cuid())
+  id   Int    @id @unique @default(autoincrement())
   name String @unique
 
   ticketsOnTags TagsOnTickets[]
@@ -66,9 +67,9 @@ model Tag {
 
 model TagsOnTickets {
   ticket   Ticket @relation(fields: [ticketId], references: [id], onDelete: Cascade)
-  ticketId String
+  ticketId Int
   tag      Tag    @relation(fields: [tagId], references: [id], onDelete: Cascade)
-  tagId    String
+  tagId    Int
 
   assignedAt DateTime @default(now())
 
@@ -78,9 +79,9 @@ model TagsOnTickets {
 
 model UserTagSubscription {
   user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId String
+  userId Int
   tag    Tag    @relation(fields: [tagId], references: [id], onDelete: Cascade)
-  tagId  String
+  tagId  Int
 
   subscribedAt DateTime @default(now())
 


### PR DESCRIPTION
## What changed
- Added incremental IDs.
- Changed id on user table to slack_id. Most of the changes are to reflect this.

## Why?
- Database performance is increased by using an integer primary key instead of a string. This means faster index performance (sequential IDs also help with this).
- Pagination is now possible in a performant manner, which is important for the upcoming GraphQL API endpoint.

See https://mydbanotebook.org/posts/pgsql-phriday-%23015-primary-keys-uuid-cuid-or-tsid/

## Tradeoffs
- Fetching the Slack ID of a user is slightly more complex now. However, given that the user model was usually fetched anyway, it's not too big of a deal.