### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hackclub/nephthys/security/code-scanning/1](https://github.com/hackclub/nephthys/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow appears to involve checking out the repository, setting up Python, and running pre-commit hooks, it likely only requires read access to the repository contents. We will set `contents: read` at the root of the workflow to apply this permission to all jobs. This ensures that the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
