### PR TITLE
Always save datetimes as UTC into the database

### DIFF
--- a/nephthys/events/message.py
+++ b/nephthys/events/message.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timezone
 from typing import Any
 from typing import Dict
 
@@ -63,9 +64,11 @@ async def on_message(event: Dict[str, Any], client: AsyncWebClient):
                     data={
                         "assignedTo": {"connect": {"id": db_user.id}},
                         "status": TicketStatus.IN_PROGRESS,
-                        "assignedAt": datetime.now()
-                        if not ticket.assignedAt
-                        else ticket.assignedAt,
+                        "assignedAt": (
+                            datetime.now(timezone.utc)
+                            if not ticket.assignedAt
+                            else ticket.assignedAt
+                        ),
                     },
                 )
         return

--- a/nephthys/tasks/close_stale.py
+++ b/nephthys/tasks/close_stale.py
@@ -56,7 +56,7 @@ async def get_is_stale(ts: str, max_retries: int = 3) -> bool:
                         where={"msgTs": ts},
                         data={
                             "status": TicketStatus.CLOSED,
-                            "closedAt": datetime.now(),
+                            "closedAt": datetime.now(timezone.utc),
                             "closedBy": {"connect": {"id": maintainer_user.id}},
                         },
                     )
@@ -65,7 +65,7 @@ async def get_is_stale(ts: str, max_retries: int = 3) -> bool:
                         where={"msgTs": ts},
                         data={
                             "status": TicketStatus.CLOSED,
-                            "closedAt": datetime.now(),
+                            "closedAt": datetime.now(timezone.utc),
                         },
                     )
                 return False


### PR DESCRIPTION
I noticed a bug while hacking on the bot: the `assignedAt` and `closedAt` ISO-6801 datetime strings claimed to be in UTC (ended with `Z`), but the Python code was saving them with the local timezone offset applied. The `createdAt` datetime string is in UTC as expected.

This means that when I'm in BST, the `closedAt` and `assignedAt` timestamps are 1 hour late. This meant that the lag time was being reported as 65 mins instead of 60 mins or whatever.

I assume this doesn't affect the production bot as it's run with timezone set to UTC.

Anyway, yap over, here's a PR that fixes it.

### Screenshots

#### Before (incorrect behaviour)

Look! some of the hours don't line up! (expected all the hours to be 15)

<img width="1247" height="203" alt="Screenshot_20250805_170124" src="https://github.com/user-attachments/assets/1bb84b31-2388-499b-80b7-cbbec915aac4" />

#### After

All timestamps are consistently in UTC :relieved: 

(expected all the hours to be 16 because some time had passed since the first screenshot)

<img width="1212" height="65" alt="Screenshot_20250805_170734" src="https://github.com/user-attachments/assets/2fb5b661-7a6c-4021-a9f2-e67d978e2bc6" />
