### PR TITLE
Ignore bot messages in the support channel

### DIFF
--- a/nephthys/events/message.py
+++ b/nephthys/events/message.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from typing import Any
 from typing import Dict
@@ -17,6 +18,9 @@ async def on_message(event: Dict[str, Any], client: AsyncWebClient):
     Handle incoming messages in Slack.
     """
     if "subtype" in event and event["subtype"] not in ALLOWED_SUBTYPES:
+        return
+    if "bot_id" in event:
+        logging.info(f"Ignoring bot message from {event['bot_id']}")
         return
 
     user = event.get("user", "unknown")
@@ -63,9 +67,11 @@ async def on_message(event: Dict[str, Any], client: AsyncWebClient):
                     data={
                         "assignedTo": {"connect": {"id": db_user.id}},
                         "status": TicketStatus.IN_PROGRESS,
-                        "assignedAt": datetime.now()
-                        if not ticket.assignedAt
-                        else ticket.assignedAt,
+                        "assignedAt": (
+                            datetime.now()
+                            if not ticket.assignedAt
+                            else ticket.assignedAt
+                        ),
                     },
                 )
         return


### PR DESCRIPTION
We probably don't want to start a support thread if a bot sends a message in a support channel. This PR ensures bot messages are ignored.

Here's a beautiful demo image:
<img width="744" height="360" alt="image" src="https://github.com/user-attachments/assets/548eb639-da29-43b9-bc3b-35759c8fa0a6" />

This should make something like this [screenshot below] less annoying
<img width="796" height="264" alt="image" src="https://github.com/user-attachments/assets/fb8bc532-28f2-411f-bbc9-f56c08e3ab9d" />

