### PR TITLE
Improve performance of pie chart generation by using `db.ticket.count()`

### DIFF
--- a/nephthys/views/home/components/ticket_status_pie.py
+++ b/nephthys/views/home/components/ticket_status_pie.py
@@ -41,7 +41,7 @@ async def get_ticket_status_pie_chart(
     )
     open_tickets = await env.db.ticket.count(where={"status": TicketStatus.OPEN})
     time_get_tickets = perf_counter()
-    logging.info(f"Fetched tickets in {time_get_tickets - time_start:.4f} seconds")
+    logging.debug(f"Fetched tickets in {time_get_tickets - time_start:.4f} seconds")
 
     y = [recently_closed_tickets, in_progress_tickets, open_tickets]
     labels = ["Closed", "In Progress", "Open"]
@@ -70,14 +70,14 @@ async def get_ticket_status_pie_chart(
         bg_colour=bg_colour,
     )
     time_generate_chart = perf_counter()
-    logging.info(
+    logging.debug(
         f"Built pie chart in {time_generate_chart - time_get_tickets:.4f} seconds"
     )
     plt.savefig(
         b, bbox_inches="tight", pad_inches=0.1, transparent=False, dpi=300, format="png"
     )
     time_save_chart = perf_counter()
-    logging.info(
+    logging.debug(
         f"Saved pie chart to buffer in {time_save_chart - time_generate_chart:.4f} seconds"
     )
 
@@ -92,7 +92,7 @@ async def get_ticket_status_pie_chart(
         content_type="image/png",
     )
     time_upload_file = perf_counter()
-    logging.info(
+    logging.debug(
         f"Uploaded pie chart in {time_upload_file - time_save_chart:.4f} seconds"
     )
     caption = "Ticket stats"

--- a/nephthys/views/home/helper.py
+++ b/nephthys/views/home/helper.py
@@ -15,7 +15,7 @@ async def get_helper_view(user: User):
     time_start = perf_counter()
     user_info = await env.slack_client.users_info(user=user.slackId)
     time_user_info = perf_counter()
-    logging.info(f"Fetched user info in {time_user_info - time_start:.4f} seconds")
+    logging.debug(f"Fetched user info in {time_user_info - time_start:.4f} seconds")
     if not user_info or not (slack_user := user_info.get("user")):
         return get_error_view(
             ":rac_freaking: oops, i couldn't find your info! try again in a bit?"
@@ -25,16 +25,18 @@ async def get_helper_view(user: User):
 
     pie_chart = await get_ticket_status_pie_chart(tz)
     time_pie_chart = perf_counter()
-    logging.info(f"Rendered pie chart in {time_pie_chart - time_user_info:.4f} seconds")
+    logging.debug(
+        f"Rendered pie chart in {time_pie_chart - time_user_info:.4f} seconds total"
+    )
     leaderboard = await get_leaderboard_view()
     time_leaderboard = perf_counter()
-    logging.info(
+    logging.debug(
         f"Generated leaderboard in {time_leaderboard - time_pie_chart:.4f} seconds"
     )
 
     btns = get_buttons(user, "dashboard")
-    logging.info(
-        f"Generated Dashboard view in {perf_counter() - time_start:.4f} seconds"
+    logging.debug(
+        f"Generated Dashboard view in {perf_counter() - time_start:.4f} seconds total"
     )
 
     return {


### PR DESCRIPTION
Instead of fetching all tickets and then filtering and counting them up in Python, we just ask the database for a count of tickets that match our filters.

This PR only touches pie chart generation. There may be performance gains to be found elsewhere too!

### How much faster?

I tested with 20k synthetic ticket records.

Querying the database used to take 0.25s avg, now the query takes 0.028s avg.

Generating pie chart used to take 1.3s, now it's 0.74s. That's a 43% speedup I think! Although the pie chart isn't the only thing that takes time to load on the dashboard, so the overall dashboard speedup is less than that.

### Profiling results

This PR also includes a bunch of `time.perf_counter()` calls I added as a crude way of profiling the dashboard generation. I wasn't sure whether to leave them in or not, so I've settled for downgrading the profiling logs to DEBUG level (not shown by default). lmk if you think they clutter the code too much. There's also probably a better way of profiling code :upside_down_face:

Anyway, here's what the results look like (on my machine, with labels and indentation added for clarity):

```
Dashboard:
	INFO:root:Fetched user info in 0.1646 seconds
	Pie chart:
		INFO:root:Fetched tickets in 0.0399 seconds
		INFO:root:Built pie chart in 0.1187 seconds
		INFO:root:Saved pie chart to buffer in 0.0861 seconds
		INFO:root:Uploaded pie chart in 0.6827 seconds
	INFO:root:Rendered pie chart in 0.9278 seconds
	INFO:root:Generated leaderboard in 0.8213 seconds
INFO:root:Generated Dashboard view in 1.9140 seconds
```