### PR TITLE
Add a VSCode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: Run Nephthys",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/nephthys/__main__.py",
+      "console": "integratedTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
I use VSCode so something like this is quite handy to have.

But maybe it should be .gitignored instead - I can do that if that's deemed better.