### PR TITLE
Add required library libatomic1 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ADD . /app
 WORKDIR /app
 
 RUN apt update
-RUN apt install -y curl
+RUN apt install -y curl libatomic1
 
 RUN uv python install
 RUN uv sync --frozen


### PR DESCRIPTION
Coolify builds were failing, which I do not appreciate:
```
#15 [stage-0 9/9] RUN prisma db push
#15 1.304 Installing Prisma CLI
#15 1.528  * Install prebuilt node (25.0.0) ../app/.venv/lib/python3.13/site-packages/nodeenv.py:639: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
#15 4.330   archive.extractall(src_dir, extract_list)
#15 7.603 ... done.
#15 8.938 An error ocurred while installing the Prisma CLI; npm install log: node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
#15 8.938
#15 8.939 Traceback (most recent call last):
#15 8.940   File "/app/.venv/bin/prisma", line 10, in <module>
#15 8.940     sys.exit(main())
#15 8.940              ~~~~^^
#15 8.940   File "/app/.venv/lib/python3.13/site-packages/prisma/cli/cli.py", line 37, in main
#15 8.940     sys.exit(prisma.run(args[1:]))
#15 8.940              ~~~~~~~~~~^^^^^^^^^^
#15 8.940   File "/app/.venv/lib/python3.13/site-packages/prisma/cli/prisma.py", line 35, in run
#15 8.940     entrypoint = ensure_cached().entrypoint
#15 8.940                  ~~~~~~~~~~~~~^^
#15 8.940   File "/app/.venv/lib/python3.13/site-packages/prisma/cli/prisma.py", line 99, in ensure_cached
#15 8.940     proc.check_returncode()
#15 8.940     ~~~~~~~~~~~~~~~~~~~~~^^
#15 8.940   File "/root/.local/share/uv/python/cpython-3.13.9-linux-x86_64-gnu/lib/python3.13/subprocess.py", line 508, in check_returncode
#15 8.940     raise CalledProcessError(self.returncode, self.args, self.stdout,
#15 8.940                              self.stderr)
#15 8.940 subprocess.CalledProcessError: Command '['/root/.cache/prisma-python/nodeenv/bin/npm', 'install', 'prisma@5.17.0']' returned non-zero exit status 127.
#15 ERROR: process "/bin/sh -c prisma db push" did not complete successfully: exit code: 1 
```

This PR should fix em!