### PR TITLE
Add reopen macro

### DIFF
--- a/nephthys/macros/__init__.py
+++ b/nephthys/macros/__init__.py
@@ -4,6 +4,7 @@ from nephthys.macros.faq import FAQ
 from nephthys.macros.fraud import Fraud
 from nephthys.macros.hello_world import HelloWorld
 from nephthys.macros.identity import Identity
+from nephthys.macros.reopen import Reopen
 from nephthys.macros.resolve import Resolve
 from nephthys.macros.shipcertqueue import ShipCertQueue
 from nephthys.macros.thread import Thread
@@ -13,7 +14,7 @@ from prisma.models import Ticket
 from prisma.models import User
 
 
-macros = [Resolve, HelloWorld, FAQ, Identity, Fraud, ShipCertQueue, Thread]
+macros = [Resolve, HelloWorld, FAQ, Identity, Fraud, ShipCertQueue, Thread, Reopen]
 
 
 async def run_macro(

--- a/nephthys/macros/reopen.py
+++ b/nephthys/macros/reopen.py
@@ -1,0 +1,99 @@
+from datetime import datetime 
+
+from nephthys.macros.types import Macro
+from nephthys.utils.env import env
+from nephthys.utils.logging import send_heartbeat
+from nephthys.utils.ticket_methods import reply_to_ticket
+from prisma.enums import TicketStatus
+
+class Reopen(Macro):
+    name = "reopen"
+
+    async def run(self, ticket, helper, **kwargs):
+        """
+        A simple macro to reopen a closed ticket
+        """
+        if ticket.status != TicketStatus.CLOSED:
+            return
+
+        await env.db.ticket.update(
+            where={"id": ticket.id},
+            data={
+                "status": TicketStatus.OPEN,
+                "closedBy": {"disconnect": True},
+                "closedAt": None,
+            },
+        )
+
+        await reply_to_ticket(
+            text=f"The ticket was reopened by <@{helper.slackId}>. Someone will be with you shortly ty!",
+            ticket=ticket,
+            client=env.slack_client,
+        )
+
+        user_info = await env.slack_client.users_info(user=ticket.openedBy.slackId)
+        name = (
+            user_info["user"]["profile"]["display_name"]
+            or user_info["user"]["real_name"]
+            or "Explorer"
+        )
+        profile_pic = user_info["user"]["profile"].get("image_512", "")
+        thread_url = f"https://hackclub.slack.com/archives/{env.slack_help_channel}/p{ticket.msgTs.replace('.', '')}"
+
+        use_impersonation = await env.workspace_admin_available()
+
+        backend_message = await env.slack_client.chat_postMessage(
+            channel=env.slack_ticket_channel,
+            text=f"Reopened ticket from <@{ticket.openedBy.slackId}>: {ticket.description}",
+            blocks=[
+                {
+                    "type": "input",
+                    "label": {"type": "plain_text", "text": "Tag ticket", "emoji": True},
+                    "element": {
+                        "action_id": "tag-list",
+                        "type": "multi_external_select",
+                        "placeholder": {"type": "plain_text", "text": "Select tags"},
+                        "min_query_length": 0,
+                    },
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": f"Reopened by <@{helper.slackId}>. Originally submitted by <@{ticket.openedBy.slackId}>. <{thread_url}|View thread>.",
+                        }
+                    ],
+                },
+            ],
+            username=display_name if use_impersonation else None,
+            icon_url=profile_pic if use_impersonation else None,
+            unfurl_links=True,
+            unfurl_media=True,
+        )
+
+        new_ticket_ts = backend_message["ts"]
+        await env.db.ticket.update(
+            where={"id": ticket.id},
+            data={"ticketTs": new_ticket_ts},
+        )
+
+        await env.slack_client.reactions_remove(
+            channel=env.slack_help_channel,
+            name="white_check_mark",
+            timestamp=ticket.msgTs,
+        )
+        await env.slack_client.reactions_add(
+            channel=env.slack_help_channel,
+            name="thinking_face",
+            timestamp=ticket.msgTs,
+        )
+
+        await send_heartbeat(
+            f"Ticket {ticket.id} reopened by <@{helper.slackId}>",
+            messages=[
+                f"Ticket ID: {ticket.id}",
+                f"Original TS: {ticket.msgTs}",
+                f"New TS: {new_ticket_ts}",
+            ],
+        )


### PR DESCRIPTION
This adds a `?reopen` macro for support team members that allows for (only closed) tickets to be reopened. 
Reopening tickets sends a user-facing message saying that the ticket has been reopened, and also sends a message in the internal tickets channel. 

<img width="404" alt="image" src="https://github.com/user-attachments/assets/3de3e358-29d1-4b1b-8d6a-b1bc30134109" />
