### PR TITLE
chore: describe package in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "nephthys"
 version = "0.1.0"
-description = "Add your description here"
+description = "Slack support bot for Hack Club's Summer of Making help channels"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [


### PR DESCRIPTION
## Summary
- replace the placeholder description in `pyproject.toml` with wording that matches the README

## Rationale
- the package metadata now explains that Nephthys is the Slack support bot for Summer of Making help channels, aligning with issue #97

## Testing
- not run (metadata-only change)

Fixes #97
