### PR TITLE
Make logging level configurable with an env var

### DIFF
--- a/nephthys/__main__.py
+++ b/nephthys/__main__.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     pass
 
-logging.basicConfig(level="INFO" if env.environment != "production" else "WARNING")
+logging.basicConfig(level=env.log_level)
 
 
 @contextlib.asynccontextmanager

--- a/nephthys/utils/env.py
+++ b/nephthys/utils/env.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Literal
 
@@ -24,6 +25,11 @@ class Environment:
         self.site_api_key = os.environ.get("SITE_API_KEY", "unset")
 
         self.environment = os.environ.get("ENVIRONMENT", "development")
+        self.log_level = os.environ.get(
+            "LOG_LEVEL",
+            logging.INFO if self.environment == "production" else logging.WARNING,
+        )
+
         self.slack_help_channel = os.environ.get("SLACK_HELP_CHANNEL", "unset")
         self.slack_ticket_channel = os.environ.get("SLACK_TICKET_CHANNEL", "unset")
         self.slack_bts_channel = os.environ.get("SLACK_BTS_CHANNEL", "unset")


### PR DESCRIPTION
Make logging level configurable with an env var - e.g. `LOG_LEVEL=DEBUG nephthys` now works

Default behaviour remains the same.