### PR TITLE
Ensure the Prisma VSCode extension sticks with Prisma v6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prisma.pinToPrisma6": true
+}


### PR DESCRIPTION
Prisma v7 is JS-only, so I assume we won't ever be migrating to it :pf:

This change only affects devs using the Prisma extension for VSCode (me!)