### PR TITLE
Fix the alaninnovates bug

### DIFF
--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -104,3 +104,5 @@ async def resolve(
         await delete_message(
             channel_id=env.slack_ticket_channel, message_ts=tkt.ticketTs
         )
+
+    logging.info(f"Resolved ticket ts={ts} resolving_user={resolving_user.slackId}")


### PR DESCRIPTION
Fixes a bug where if a ticket is resolved by the OP, the helper who helped wouldn't get attributed for that.

This change is not retroactive so stats won't be updated - but they'll be more accurate for any future tickets.

`closedBy` now stores the _helper_ who resolved the ticket (instead of who clicked the Resolve button, which may be OP). This was the original intended behavior.