### PR TITLE
feat(macros): Hackatime macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Sometimes it’s nice to be able to do things quickly... Here’s where macros c
 - `?fraud` - redirect to Fraud Squad
 - `?thread` - remove the reaction and all Nephthys replies to unclutter duplicates
 - `?shipwrights` - redirect to #ask-the-shipwrights
+- `?hackatime` - redirect to #hackatime-help
 - more to come?? feel free to PR your own into hackclub/nephthys or tell me what you want
 
 ### Stale

--- a/nephthys/macros/__init__.py
+++ b/nephthys/macros/__init__.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from nephthys.macros.faq import FAQ
 from nephthys.macros.fraud import Fraud
+from nephthys.macros.hackatime import Hackatime
 from nephthys.macros.hello_world import HelloWorld
 from nephthys.macros.identity import Identity
 from nephthys.macros.reopen import Reopen
@@ -32,6 +33,7 @@ macro_list: list[type[Macro]] = [
     FulfillmentReminder,
     Shipwrights,
     TeamTag,
+    Hackatime,
 ]
 
 macros = [macro() for macro in macro_list]

--- a/nephthys/macros/hackatime.py
+++ b/nephthys/macros/hackatime.py
@@ -1,0 +1,29 @@
+from nephthys.actions.resolve import resolve
+from nephthys.macros.types import Macro
+from nephthys.utils.env import env
+from nephthys.utils.slack_user import get_user_profile
+from nephthys.utils.ticket_methods import reply_to_ticket
+
+
+class Hackatime(Macro):
+    name = "hackatime"
+
+    async def run(self, ticket, helper, **kwargs):
+        """
+        A simple macro telling people to use #hackatime-help.
+        """
+        sender = await env.db.user.find_first(where={"id": ticket.openedById})
+        if not sender:
+            return
+        user = await get_user_profile(sender.slackId)
+        await reply_to_ticket(
+            text=env.transcript.hackatime_macro.replace("(user)", user.display_name()),
+            ticket=ticket,
+            client=env.slack_client,
+        )
+        await resolve(
+            ts=ticket.msgTs,
+            resolver=helper.slackId,
+            client=env.slack_client,
+            send_resolved_message=False,
+        )

--- a/nephthys/transcripts/transcript.py
+++ b/nephthys/transcripts/transcript.py
@@ -101,7 +101,7 @@ class Transcript(BaseModel):
     )
 
     hackatime_macro: str = Field(
-        default="Hi (user), could you ask that question in <#C0AFG0XGGMP>? :rac_cute:\n\nIt helps us keep track of Hackatime-related questions easier!\n\n_I've marked this thread as resolved_",
+        default="Hi (user), could you ask that question in <#C0AFG0XGGMP>? :rac_cute:\n\nYou'll get better help for this Hackatime-specific question there!\n\n_I've marked this thread as resolved_",
         description="Message to be sent when the Hackatime macro is used",
     )
 

--- a/nephthys/transcripts/transcript.py
+++ b/nephthys/transcripts/transcript.py
@@ -100,6 +100,11 @@ class Transcript(BaseModel):
         description="Message to be sent when the ship cert queue macro is used (only applies to Flavortown and SoM)",
     )
 
+    hackatime_macro: str = Field(
+        default="Hi (user), could you ask that question in <#C0AFG0XGGMP>? :rac_cute:\n\nIt helps us keep track of Hackatime-related questions easier!\n\n_I've marked this thread as resolved_",
+        description="Message to be sent when the Hackatime macro is used",
+    )
+
     not_allowed_channel: str = Field(
         default="", description="Message for unauthorized channel access"
     )


### PR DESCRIPTION
This macro tells people to use #hackatime-help.

Flavortown wants people to use #hackatime-help instead of #flavortown-help, so I added a macro similar to ?identity that redirects people to the correct channel.

***

Default response (pretty Flavortowny):
> Hi (user), could you ask that question in <#C0AFG0XGGMP>? :rac_cute:
>
> It helps us keep track of Hackatime-related questions easier!
>
> _I've marked this thread as resolved_