### PR TITLE
Allow users to re-open their own tickets

### DIFF
--- a/nephthys/actions/reopen.py
+++ b/nephthys/actions/reopen.py
@@ -7,18 +7,29 @@ from slack_sdk.web.async_client import AsyncWebClient
 from nephthys.database.enums import TicketStatus
 from nephthys.database.tables import Ticket
 from nephthys.database.tables import User
+from nephthys.errors.errors import PermissionDenied
 from nephthys.errors.errors import TicketNotClosedError
 from nephthys.events.message.send_backend_message import send_backend_message
 from nephthys.utils.env import env
 from nephthys.utils.logging import send_heartbeat
+from nephthys.utils.permissions import can_resolve
 from nephthys.utils.slack_user import get_user_profile
 from nephthys.utils.ticket_methods import reply_to_ticket
 
 
 async def reopen(ticket: Ticket, reopened_by: User, client: AsyncWebClient):
-    """The opposite of resolving! Makes a resolved ticket open again"""
+    """The opposite of resolving! Makes a resolved ticket open again
+
+    Checks if the user user is allowed to reopen the ticket, raising a
+    `PermissionDenied` error if not.
+    """
     if ticket.status != TicketStatus.CLOSED:
         raise TicketNotClosedError(ticket.id)
+    if not await can_resolve(reopened_by.slack_id, reopened_by.id, ticket.msg_ts):
+        raise PermissionDenied(
+            "Only helpers or the original author can reopen a ticket",
+            user_id=reopened_by.id,
+        )
 
     await Ticket.update(
         {

--- a/nephthys/actions/reopen.py
+++ b/nephthys/actions/reopen.py
@@ -7,6 +7,7 @@ from slack_sdk.web.async_client import AsyncWebClient
 from nephthys.database.enums import TicketStatus
 from nephthys.database.tables import Ticket
 from nephthys.database.tables import User
+from nephthys.errors.errors import TicketNotClosedError
 from nephthys.events.message.send_backend_message import send_backend_message
 from nephthys.utils.env import env
 from nephthys.utils.logging import send_heartbeat
@@ -17,7 +18,7 @@ from nephthys.utils.ticket_methods import reply_to_ticket
 async def reopen(ticket: Ticket, reopened_by: User, client: AsyncWebClient):
     """The opposite of resolving! Makes a resolved ticket open again"""
     if ticket.status != TicketStatus.CLOSED:
-        raise ValueError("Cannot reopen non-closed ticket")
+        raise TicketNotClosedError(ticket.id)
 
     await Ticket.update(
         {
@@ -35,24 +36,23 @@ async def reopen(ticket: Ticket, reopened_by: User, client: AsyncWebClient):
         client=env.slack_client,
     )
 
-    if not ticket.opened_by:
+    if not (author := await User.objects().get(User.id == ticket.opened_by)):
         raise ValueError("Cannot reopen ticket with no recorded author")
-    author_id = ticket.opened_by.slack_id
-    author = await get_user_profile(author_id)
+    author_profile = await get_user_profile(author.slack_id)
     other_tickets = await Ticket.count().where(
         (Ticket.opened_by == ticket.opened_by) & (Ticket.id != ticket.id)
     )
 
     backend_message = await send_backend_message(
-        author_user_id=author_id,
+        author_user_id=author.slack_id,
         description=ticket.description,
         msg_ts=ticket.msg_ts,
         past_tickets=other_tickets,
         client=env.slack_client,
         current_category_tag_id=ticket.category_tag,
         reopened_by=reopened_by,
-        display_name=author.display_name(),
-        profile_pic=author.profile_pic_512x(),
+        display_name=author_profile.display_name(),
+        profile_pic=author_profile.profile_pic_512x(),
     )
 
     new_ticket_ts = backend_message["ts"]

--- a/nephthys/actions/reopen.py
+++ b/nephthys/actions/reopen.py
@@ -1,0 +1,91 @@
+import logging
+from datetime import datetime
+
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.async_client import AsyncWebClient
+
+from nephthys.database.enums import TicketStatus
+from nephthys.database.tables import Ticket
+from nephthys.database.tables import User
+from nephthys.events.message.send_backend_message import send_backend_message
+from nephthys.utils.env import env
+from nephthys.utils.logging import send_heartbeat
+from nephthys.utils.slack_user import get_user_profile
+from nephthys.utils.ticket_methods import reply_to_ticket
+
+
+async def reopen(ticket: Ticket, reopened_by: User, client: AsyncWebClient):
+    """The opposite of resolving! Makes a resolved ticket open again"""
+    if ticket.status != TicketStatus.CLOSED:
+        raise ValueError("Cannot reopen non-closed ticket")
+
+    await Ticket.update(
+        {
+            Ticket.status: TicketStatus.OPEN,
+            Ticket.closed_by: None,
+            Ticket.reopened_by: reopened_by,
+            Ticket.reopened_at: datetime.now(),
+            Ticket.closed_at: None,
+        }
+    ).where(Ticket.id == ticket.id)
+
+    await reply_to_ticket(
+        text=env.transcript.ticket_reopen.format(helper_slack_id=reopened_by.slack_id),
+        ticket=ticket,
+        client=env.slack_client,
+    )
+
+    if not ticket.opened_by:
+        raise ValueError("Cannot reopen ticket with no recorded author")
+    author_id = ticket.opened_by.slack_id
+    author = await get_user_profile(author_id)
+    other_tickets = await Ticket.count().where(
+        (Ticket.opened_by == ticket.opened_by) & (Ticket.id != ticket.id)
+    )
+
+    backend_message = await send_backend_message(
+        author_user_id=author_id,
+        description=ticket.description,
+        msg_ts=ticket.msg_ts,
+        past_tickets=other_tickets,
+        client=env.slack_client,
+        current_category_tag_id=ticket.category_tag,
+        reopened_by=reopened_by,
+        display_name=author.display_name(),
+        profile_pic=author.profile_pic_512x(),
+    )
+
+    new_ticket_ts = backend_message["ts"]
+    if not new_ticket_ts:
+        logging.error(f"Invalid Slack message creation response: {backend_message}")
+        raise ValueError("Invalid Slack message creation response: no ts")
+    await Ticket.update(
+        {
+            Ticket.ticket_ts: new_ticket_ts,
+        }
+    ).where(Ticket.id == ticket.id)
+
+    try:
+        await env.slack_client.reactions_remove(
+            channel=env.slack_help_channel,
+            name="white_check_mark",
+            timestamp=ticket.msg_ts,
+        )
+    except SlackApiError as e:
+        logging.error(
+            f"Failed to remove check reaction from ticket with ts {ticket.msg_ts}: {e.response['error']}"
+        )
+    await env.slack_client.reactions_add(
+        channel=env.slack_help_channel,
+        name="thinking_face",
+        timestamp=ticket.msg_ts,
+    )
+
+    await send_heartbeat(
+        f"Ticket {ticket.id} reopened by <@{reopened_by.slack_id}>",
+        messages=[
+            f"Ticket ID: {ticket.id}",
+            f"Original TS: {ticket.msg_ts}",
+            f"New TS: {new_ticket_ts}",
+        ],
+    )

--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -1,6 +1,9 @@
 import logging
 from datetime import datetime
 
+from blockkit import Actions
+from blockkit import Button
+from blockkit import Section
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
@@ -74,15 +77,35 @@ async def resolve(
         )
         return
 
+    # Build the "ticket resolved!" message
+    text = (
+        env.transcript.ticket_resolve.format(user_id=resolver)
+        if not stale
+        else env.transcript.ticket_resolve_stale.format(user_id=resolver)
+    )
+    actions = Actions()
+    if env.enable_feedback:
+        actions.add_element(
+            Button(
+                text="Give feedback",
+                action_id="feedback-button",
+                value=f"{tkt.id}",
+            )
+        )
+    actions.add_element(
+        Button(
+            text="Re-open thread",
+            action_id="reopen-button",
+            value=f"{tkt.id}",
+        )
+    )
+
     if send_resolved_message:
         await reply_to_ticket(
             ticket=tkt,
             client=client,
-            text=(
-                env.transcript.ticket_resolve.format(user_id=resolver)
-                if not stale
-                else env.transcript.ticket_resolve_stale.format(user_id=resolver)
-            ),
+            text=text,
+            blocks=[Section(text), actions],
         )
     if add_reaction:
         await client.reactions_add(

--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -41,14 +41,15 @@ async def resolve(
             messages=[f"Ticket TS: {ts}", f"Resolver ID: {resolver}"],
         )
         return
-    ticket = (
-        await Ticket.objects(Ticket.assigned_to)
-        .where((Ticket.msg_ts == ts) & (Ticket.status != TicketStatus.CLOSED))
-        .first()
-    )
+    ticket = await Ticket.objects(Ticket.assigned_to).get((Ticket.msg_ts == ts))
     if not ticket:
-        logging.warning(
-            f"Failed to resolve ticket ts={ts} because it's already closed or doesn't exist."
+        raise ValueError(f"Failed to find ticket with ts {ts}")
+    if ticket.status == TicketStatus.CLOSED:
+        await client.chat_postEphemeral(
+            channel=env.slack_help_channel,
+            thread_ts=ticket.msg_ts,
+            user=resolver,
+            text="Cannot mark as resolved — this ticket is already resolved!",
         )
         return
 

--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -40,7 +40,14 @@ async def resolve(
             f"User {resolver} attempted to resolve ticket with ts {ts} without permission.",
             messages=[f"Ticket TS: {ts}", f"Resolver ID: {resolver}"],
         )
+        await client.chat_postEphemeral(
+            channel=env.slack_help_channel,
+            thread_ts=ts,
+            user=resolver,
+            text="Only helpers or the original poster can mark this thread as resolved.",
+        )
         return
+
     ticket = await Ticket.objects(Ticket.assigned_to).get((Ticket.msg_ts == ts))
     if not ticket:
         raise ValueError(f"Failed to find ticket with ts {ts}")

--- a/nephthys/errors/errors.py
+++ b/nephthys/errors/errors.py
@@ -2,3 +2,9 @@ class TicketNotClosedError(Exception):
     def __init__(self, ticket_id: int):
         super().__init__("Cannot reopen a non-closed ticket")
         self.ticket_id = ticket_id
+
+
+class PermissionDenied(Exception):
+    def __init__(self, message: str, user_id: int):
+        super().__init__(message)
+        self.user_id = user_id

--- a/nephthys/errors/errors.py
+++ b/nephthys/errors/errors.py
@@ -1,0 +1,4 @@
+class TicketNotClosedError(Exception):
+    def __init__(self, ticket_id: int):
+        super().__init__("Cannot reopen a non-closed ticket")
+        self.ticket_id = ticket_id

--- a/nephthys/macros/reopen.py
+++ b/nephthys/macros/reopen.py
@@ -1,5 +1,5 @@
 from nephthys.actions.reopen import reopen
-from nephthys.database.enums import TicketStatus
+from nephthys.errors.errors import TicketNotClosedError
 from nephthys.macros.types import Macro
 from nephthys.utils.env import env
 
@@ -13,13 +13,12 @@ class Reopen(Macro):
         """
         A simple macro to reopen a closed ticket
         """
-        if ticket.status != TicketStatus.CLOSED:
+        try:
+            await reopen(ticket, helper, env.slack_client)
+        except TicketNotClosedError:
             await env.slack_client.chat_postEphemeral(
                 channel=env.slack_help_channel,
                 thread_ts=ticket.msg_ts,
                 user=helper.slack_id,
                 text="Cannot reopen — this ticket isn't resolved!",
             )
-            return
-
-        await reopen(ticket, helper, env.slack_client)

--- a/nephthys/macros/reopen.py
+++ b/nephthys/macros/reopen.py
@@ -1,16 +1,7 @@
-import logging
-from datetime import datetime
-
-from slack_sdk.errors import SlackApiError
-
+from nephthys.actions.reopen import reopen
 from nephthys.database.enums import TicketStatus
-from nephthys.database.tables import Ticket
-from nephthys.events.message.send_backend_message import send_backend_message
 from nephthys.macros.types import Macro
 from nephthys.utils.env import env
-from nephthys.utils.logging import send_heartbeat
-from nephthys.utils.slack_user import get_user_profile
-from nephthys.utils.ticket_methods import reply_to_ticket
 
 
 class Reopen(Macro):
@@ -23,78 +14,12 @@ class Reopen(Macro):
         A simple macro to reopen a closed ticket
         """
         if ticket.status != TicketStatus.CLOSED:
-            return
-
-        await Ticket.update(
-            {
-                Ticket.status: TicketStatus.OPEN,
-                Ticket.closed_by: None,
-                Ticket.reopened_by: helper.id,
-                Ticket.reopened_at: datetime.now(),
-                Ticket.closed_at: None,
-            }
-        ).where(Ticket.id == ticket.id)
-
-        await reply_to_ticket(
-            text=env.transcript.ticket_reopen.format(helper_slack_id=helper.slack_id),
-            ticket=ticket,
-            client=env.slack_client,
-        )
-
-        if not ticket.opened_by:
-            await send_heartbeat(
-                f"Attempted to reopen ticket (TS {ticket.msg_ts}) but ticket author has not been recorded"
-            )
-            return
-        author_id = ticket.opened_by.slack_id
-        author = await get_user_profile(author_id)
-        other_tickets = await Ticket.count().where(
-            (Ticket.opened_by == ticket.opened_by) & (Ticket.id != ticket.id)
-        )
-
-        backend_message = await send_backend_message(
-            author_user_id=author_id,
-            description=ticket.description,
-            msg_ts=ticket.msg_ts,
-            past_tickets=other_tickets,
-            client=env.slack_client,
-            current_category_tag_id=ticket.category_tag,
-            reopened_by=helper,
-            display_name=author.display_name(),
-            profile_pic=author.profile_pic_512x(),
-        )
-
-        new_ticket_ts = backend_message["ts"]
-        if not new_ticket_ts:
-            logging.error(f"Invalid Slack message creation response: {backend_message}")
-            raise ValueError("Invalid Slack message creation response: no ts")
-        await Ticket.update(
-            {
-                Ticket.ticket_ts: new_ticket_ts,
-            }
-        ).where(Ticket.id == ticket.id)
-
-        try:
-            await env.slack_client.reactions_remove(
+            await env.slack_client.chat_postEphemeral(
                 channel=env.slack_help_channel,
-                name="white_check_mark",
-                timestamp=ticket.msg_ts,
+                thread_ts=ticket.msg_ts,
+                user=helper.slack_id,
+                text="Cannot reopen — this ticket isn't resolved!",
             )
-        except SlackApiError as e:
-            logging.error(
-                f"Failed to remove check reaction from ticket with ts {ticket.msg_ts}: {e.response['error']}"
-            )
-        await env.slack_client.reactions_add(
-            channel=env.slack_help_channel,
-            name="thinking_face",
-            timestamp=ticket.msg_ts,
-        )
+            return
 
-        await send_heartbeat(
-            f"Ticket {ticket.id} reopened by <@{helper.slack_id}>",
-            messages=[
-                f"Ticket ID: {ticket.id}",
-                f"Original TS: {ticket.msg_ts}",
-                f"New TS: {new_ticket_ts}",
-            ],
-        )
+        await reopen(ticket, helper, env.slack_client)

--- a/nephthys/macros/types.py
+++ b/nephthys/macros/types.py
@@ -46,8 +46,8 @@ class ReplyMacro(Macro):
         if not self.message:
             await env.slack_client.chat_postEphemeral(
                 channel=env.slack_help_channel,
-                thread_ts=ticket.msgTs,
-                user=helper.slackId,
+                thread_ts=ticket.msg_ts,
+                user=helper.slack_id,
                 text=f"Invalid macro: The `{self.name}` macro is not configured for this channel.",
             )
             return

--- a/nephthys/utils/env.py
+++ b/nephthys/utils/env.py
@@ -13,6 +13,18 @@ from nephthys.transcripts.transcript import Transcript
 load_dotenv(override=True)
 
 
+def get_environ_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name, None)
+    if value is None:
+        return default
+    value = value.strip().lower()
+    if value in {"1", "true", "t", "yes", "y", "on"}:
+        return True
+    if value in {"0", "false", "f", "no", "n", "off"}:
+        return False
+    raise ValueError(f"Invalid boolean env var {name}={value!r}")
+
+
 class Environment:
     def __init__(self):
         self.slack_bot_token = os.environ.get("SLACK_BOT_TOKEN", "unset")
@@ -56,6 +68,7 @@ class Environment:
         self.slack_maintainer_id = os.environ.get("SLACK_MAINTAINER_ID", "unset")
         self.program = os.environ.get("PROGRAM", "summer_of_making")
         self.daily_summary = True if not os.environ.get("DAILY_SUMMARY") else False
+        self.enable_feedback = get_environ_bool("ENABLE_FEEDBACK", False)
         self.app_title = os.environ.get("APP_TITLE", "helper heidi")
 
         self.port = int(os.environ.get("PORT", 3000))

--- a/nephthys/utils/permissions.py
+++ b/nephthys/utils/permissions.py
@@ -13,7 +13,7 @@ async def can_resolve(slack_id: str, user_id: int, ts: str) -> bool:
     Returns:
         bool: True if the user can resolve tickets, False otherwise.
     """
-    res = await env.slack_client.conversations_members(channel=env.slack_ticket_channel)
+    res = await env.slack_client.conversations_members(channel=env.slack_bts_channel)
     team = res.get("members", [])
 
     if slack_id in team:

--- a/nephthys/utils/slack.py
+++ b/nephthys/utils/slack.py
@@ -155,7 +155,7 @@ async def reopen_ticket(ack: AsyncAck, body: Dict[str, Any], client: AsyncWebCli
         raise ValueError(f"Failed to find ticket ticket_id={ticket_id}")
     if not (reopened_by := await User.objects().get(User.slack_id == slack_id)):
         logging.warning(
-            f"User slack_id={ticket.opened_by} not in database tried to reopen ticket_id={ticket_id}"
+            f"User slack_id={slack_id} not in database tried to reopen ticket_id={ticket_id}"
         )
         return
     try:

--- a/nephthys/utils/slack.py
+++ b/nephthys/utils/slack.py
@@ -12,9 +12,13 @@ from nephthys.actions.create_category_tag import create_category_tag_btn_callbac
 from nephthys.actions.create_category_tag import create_category_tag_view_callback
 from nephthys.actions.create_team_tag import create_team_tag_btn_callback
 from nephthys.actions.create_team_tag import create_team_tag_view_callback
+from nephthys.actions.reopen import reopen
 from nephthys.actions.resolve import resolve
 from nephthys.actions.tag_subscribe import tag_subscribe_callback
 from nephthys.commands.dm_magic_link import dm_magic_link_cmd_callback
+from nephthys.database.tables import Ticket
+from nephthys.database.tables import User
+from nephthys.errors.errors import TicketNotClosedError
 from nephthys.events.app_home_opened import on_app_home_opened
 from nephthys.events.app_home_opened import open_app_home
 from nephthys.events.channel_join import channel_join
@@ -138,6 +142,27 @@ async def assign_category_tag(
     ack: AsyncAck, body: Dict[str, Any], client: AsyncWebClient
 ):
     await assign_category_tag_callback(ack, body, client)
+
+
+# Action buttons on the "resolved ticket" message
+@app.action("reopen-button")
+async def reopen_ticket(ack: AsyncAck, body: Dict[str, Any], client: AsyncWebClient):
+    await ack()
+    ticket_id = int(body["actions"][0]["value"])
+    slack_id = body["user"]["id"]
+    if not (ticket := await Ticket.objects().get(Ticket.id == ticket_id)):
+        raise ValueError(f"Failed to find ticket ticket_id={ticket_id}")
+    if not (reopened_by := await User.objects().get(User.slack_id == slack_id)):
+        raise ValueError(f"Failed to find user with slack_id={slack_id}")
+    try:
+        await reopen(ticket, reopened_by, client)
+    except TicketNotClosedError:
+        await client.chat_postEphemeral(
+            channel=env.slack_help_channel,
+            thread_ts=ticket.msg_ts,
+            user=slack_id,
+            text="This thread has already been re-opened!",
+        )
 
 
 @app.command("/dm-magic-link")

--- a/nephthys/utils/slack.py
+++ b/nephthys/utils/slack.py
@@ -18,6 +18,7 @@ from nephthys.actions.tag_subscribe import tag_subscribe_callback
 from nephthys.commands.dm_magic_link import dm_magic_link_cmd_callback
 from nephthys.database.tables import Ticket
 from nephthys.database.tables import User
+from nephthys.errors.errors import PermissionDenied
 from nephthys.errors.errors import TicketNotClosedError
 from nephthys.events.app_home_opened import on_app_home_opened
 from nephthys.events.app_home_opened import open_app_home
@@ -153,7 +154,10 @@ async def reopen_ticket(ack: AsyncAck, body: Dict[str, Any], client: AsyncWebCli
     if not (ticket := await Ticket.objects().get(Ticket.id == ticket_id)):
         raise ValueError(f"Failed to find ticket ticket_id={ticket_id}")
     if not (reopened_by := await User.objects().get(User.slack_id == slack_id)):
-        raise ValueError(f"Failed to find user with slack_id={slack_id}")
+        logging.warning(
+            f"User slack_id={ticket.opened_by} not in database tried to reopen ticket_id={ticket_id}"
+        )
+        return
     try:
         await reopen(ticket, reopened_by, client)
     except TicketNotClosedError:
@@ -162,6 +166,13 @@ async def reopen_ticket(ack: AsyncAck, body: Dict[str, Any], client: AsyncWebCli
             thread_ts=ticket.msg_ts,
             user=slack_id,
             text="This thread has already been re-opened!",
+        )
+    except PermissionDenied:
+        await client.chat_postEphemeral(
+            channel=env.slack_help_channel,
+            thread_ts=ticket.msg_ts,
+            user=slack_id,
+            text="Only helpers or the original poster can reopen their thread.",
         )
 
 

--- a/nephthys/utils/ticket_methods.py
+++ b/nephthys/utils/ticket_methods.py
@@ -1,5 +1,6 @@
 import logging
 
+from blockkit.core import MessageBlock
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
@@ -20,7 +21,12 @@ async def delete_message(channel_id: str, message_ts: str):
         )
 
 
-async def reply_to_ticket(ticket: Ticket, client: AsyncWebClient, text: str) -> None:
+async def reply_to_ticket(
+    ticket: Ticket,
+    client: AsyncWebClient,
+    text: str,
+    blocks: list[MessageBlock] | None = None,
+) -> None:
     """Sends a user-facing message in the help thread and records it in the database"""
     channel = env.slack_help_channel
     thread_ts = ticket.msg_ts
@@ -28,6 +34,7 @@ async def reply_to_ticket(ticket: Ticket, client: AsyncWebClient, text: str) -> 
         channel=channel,
         text=text,
         thread_ts=thread_ts,
+        blocks=[block.build() for block in blocks] if blocks else None,
     )
     msg_ts = msg["ts"]
     if not msg_ts:


### PR DESCRIPTION
Question askers can now re-open their own tickets, should they wish!

<img width="877" height="195" alt="image" src="https://github.com/user-attachments/assets/a98cfb08-a152-4c90-99f9-31bd0010abbd" />

This PR also adds error messages for trying to resolve or re-open tickets you don't have permission to.

Finally, it changes the `can_resolve()` permission check to check if you're in the BTS channel - previously, the tickets channel was used, which didn't make as much sense.

This PR also lays the groundwork for ticket feedback, but that is not implemented in this PR.
