### PR TITLE
Make Slack IDs unique but Slack usernames nonunique

### DIFF
--- a/nephthys/database/raw_migration.py
+++ b/nephthys/database/raw_migration.py
@@ -1,0 +1,33 @@
+# Dummy table we use to execute raw SQL with
+from piccolo.apps.migrations.auto.migration_manager import MigrationManager
+from piccolo.table import Table
+
+
+class RawTable(Table):
+    pass
+
+
+def raw_migration(
+    migration_id: str,
+    app_name: str,
+    description: str,
+    forwards: str,
+    backwards: str | None = None,
+):
+    manager = MigrationManager(
+        migration_id=migration_id, app_name=app_name, description=description
+    )
+
+    async def run():
+        await RawTable.raw(forwards)
+
+    manager.add_raw(run)
+
+    if backwards:
+
+        async def run_backwards():
+            await RawTable.raw(backwards)
+
+        manager.add_raw_backwards(run_backwards)
+
+    return manager

--- a/nephthys/database/raw_migration.py
+++ b/nephthys/database/raw_migration.py
@@ -1,8 +1,8 @@
-# Dummy table we use to execute raw SQL with
 from piccolo.apps.migrations.auto.migration_manager import MigrationManager
 from piccolo.table import Table
 
 
+# Dummy table we use to execute raw SQL with
 class RawTable(Table):
     pass
 

--- a/nephthys/database/tables.py
+++ b/nephthys/database/tables.py
@@ -23,7 +23,7 @@ def table_ref(table: str) -> LazyTableReference:
 
 class User(Table, tablename="User"):
     id = Serial(primary_key=True, unique=True)
-    slack_id = Text(db_column_name="slackId")
+    slack_id = Text(db_column_name="slackId", unique=True)
     username = Text(null=True)
     admin = Boolean(default=False)
     helper = Boolean(default=False)

--- a/nephthys/events/message_creation.py
+++ b/nephthys/events/message_creation.py
@@ -140,7 +140,7 @@ async def handle_new_question(
         db_user_id = db_user.id
     else:
         past_tickets = 0
-        username = author.display_name()
+        username = author.username()
         async with perf_timer("Creating user in DB"):
             updated_records = (
                 await User.insert(User(slack_id=author_id, username=username))

--- a/nephthys/piccolo_migrations/nephthys_2026_05_07t10_40_49_usernames_not_unique.py
+++ b/nephthys/piccolo_migrations/nephthys_2026_05_07t10_40_49_usernames_not_unique.py
@@ -1,0 +1,28 @@
+from piccolo.apps.migrations.auto.migration_manager import MigrationManager
+from piccolo.table import Table
+
+
+ID = "2026-05-07T10:40:49:822926"
+VERSION = "1.33.0"
+DESCRIPTION = "Removes the UNIQUE INDEX from User.username"
+
+
+class RawTable(Table):
+    pass
+
+
+async def forwards():
+    manager = MigrationManager(
+        migration_id=ID, app_name="nephthys", description=DESCRIPTION
+    )
+
+    async def run():
+        # This only affects legacy (Prisma) databases, which had a
+        # UNIQUE constraint on the username field.
+        # This could fail if two users "swap" usernames, so let's
+        # just remove it.
+        await RawTable.raw("DROP INDEX IF EXISTS User_username_key")
+
+    manager.add_raw(run)
+
+    return manager

--- a/nephthys/piccolo_migrations/nephthys_2026_05_07t10_40_49_usernames_not_unique.py
+++ b/nephthys/piccolo_migrations/nephthys_2026_05_07t10_40_49_usernames_not_unique.py
@@ -21,7 +21,7 @@ async def forwards():
         # UNIQUE constraint on the username field.
         # This could fail if two users "swap" usernames, so let's
         # just remove it.
-        await RawTable.raw("DROP INDEX IF EXISTS User_username_key")
+        await RawTable.raw('''DROP INDEX IF EXISTS "User_username_key"''')
 
     manager.add_raw(run)
 

--- a/nephthys/piccolo_migrations/nephthys_2026_05_07t11_04_02_unique_slack_id.py
+++ b/nephthys/piccolo_migrations/nephthys_2026_05_07t11_04_02_unique_slack_id.py
@@ -1,0 +1,17 @@
+from nephthys.database.raw_migration import raw_migration
+
+ID = "2026-05-07T11:04:02:747643"
+VERSION = "1.33.0"
+DESCRIPTION = "Add a UNIQUE INDEX to User.slackId"
+
+
+async def forwards():
+    # Duplicate Slack IDs are invalid
+    # Also, we often look up based on Slack ID, so indexes are good here
+    return raw_migration(
+        migration_id=ID,
+        app_name="nephthys",
+        description=DESCRIPTION,
+        forwards="""CREATE UNIQUE INDEX IF NOT EXISTS User_slackId_key ON "User" ("slackId")""",
+        backwards="""DROP INDEX IF EXISTS User_slackId_key""",
+    )

--- a/nephthys/piccolo_migrations/nephthys_2026_05_07t11_04_02_unique_slack_id.py
+++ b/nephthys/piccolo_migrations/nephthys_2026_05_07t11_04_02_unique_slack_id.py
@@ -12,6 +12,6 @@ async def forwards():
         migration_id=ID,
         app_name="nephthys",
         description=DESCRIPTION,
-        forwards="""CREATE UNIQUE INDEX IF NOT EXISTS User_slackId_key ON "User" ("slackId")""",
-        backwards="""DROP INDEX IF EXISTS User_slackId_key""",
+        forwards="""CREATE UNIQUE INDEX IF NOT EXISTS "User_slackId_key" ON "User" ("slackId")""",
+        backwards='''DROP INDEX IF EXISTS "User_slackId_key"''',
     )

--- a/nephthys/utils/slack_user.py
+++ b/nephthys/utils/slack_user.py
@@ -1,5 +1,3 @@
-import logging
-
 from slack_sdk.web.async_slack_response import AsyncSlackResponse
 
 from nephthys.utils.env import env
@@ -12,18 +10,21 @@ class UserProfileWrapper:
             raise ValueError(f"Slack user not found: {users_info_response}")
         self.raw_data = user_data
 
+    def username(self) -> str:
+        """The internal Slack username that doesn't get shown in the client"""
+        username = self.raw_data.get("name")
+        if not username:
+            raise ValueError(
+                f"SOMETHING HAS GONE TERRIBLY WRONG - user has no username: {self.raw_data}"
+            )
+        return username
+
     def display_name(self) -> str:
         display_name = (
             self.raw_data["profile"].get("display_name")
             or self.raw_data["profile"].get("real_name")
-            or self.raw_data["name"]
+            or self.username()
         )
-        # This should never actually be empty but if it is, that is a major issue
-        if not display_name:
-            logging.error(
-                f"SOMETHING HAS GONE TERRIBLY WRONG - user has no username: {self.raw_data}"
-            )
-            return ""  # idk
         return display_name
 
     def profile_pic_512x(self) -> str | None:


### PR DESCRIPTION
- Slack usernames are no longer unique
	- Only affects legacy DBs
	- Fixes #199
- Ensure Slack IDs are unique
	- Only affects new DBs since legacy ones already have a unique index
- Database migrations, yippee