### PR TITLE
Improve handling of deleted threads

### DIFF
--- a/nephthys/events/message_creation.py
+++ b/nephthys/events/message_creation.py
@@ -24,6 +24,7 @@ from nephthys.utils.logging import send_heartbeat
 from nephthys.utils.performance import perf_timer
 from nephthys.utils.slack_user import get_user_profile
 from nephthys.utils.ticket_methods import delete_and_clean_up_ticket
+from nephthys.utils.ticket_methods import ThreadGoneError
 
 # Message subtypes that should be handled by on_message (messages with no subtype are always handled)
 ALLOWED_SUBTYPES = ["file_share", "me_message", "thread_broadcast"]
@@ -180,10 +181,16 @@ async def handle_new_question(
     )
     ticket_url = f"https://hackclub.slack.com/archives/{env.slack_ticket_channel}/p{ticket_message_ts.replace('.', '')}"
 
-    async with perf_timer("Sending user-facing FAQ message"):
-        user_facing_message = await send_user_facing_message(
-            event, client, text=user_facing_message_text, ticket_url=ticket_url
+    try:
+        async with perf_timer("Sending user-facing FAQ message"):
+            user_facing_message = await send_user_facing_message(
+                event, client, text=user_facing_message_text, ticket_url=ticket_url
+            )
+    except ThreadGoneError:
+        logging.warning(
+            f"Cancelling ticket-creation actions because thread appears to be gone thread_ts={event['ts']}"
         )
+        return
 
     async with perf_timer(
         "AI ticket title generation", TICKET_TITLE_GENERATION_DURATION
@@ -249,6 +256,9 @@ async def handle_new_question(
             raise e
         # This means the parent message has been deleted while we've been processing it
         # therefore we should unsend the bot messages and remove the ticket from the DB
+        logging.warning(
+            f"Top-level message for thread_ts={event['ts']} has been deleted. Cleaning up and deleting ticket_id={ticket.id}"
+        )
         await delete_and_clean_up_ticket(ticket)
 
 
@@ -267,7 +277,7 @@ async def send_user_facing_message(
     Returns:
         The Slack API response containing the posted message.
     """
-    return await client.chat_postMessage(
+    response = await client.chat_postMessage(
         channel=event["channel"],
         text=text,
         blocks=[
@@ -304,6 +314,17 @@ async def send_user_facing_message(
         unfurl_links=True,
         unfurl_media=True,
     )
+    msg: dict = response["message"]  # type: ignore (assuming it exists)
+    msg_ts = msg.get("ts")
+    if not msg_ts:
+        raise ValueError(f"User-facing message has no ts: {msg}")
+    if not msg.get("thread_ts"):
+        logging.warning(
+            f"User-facing message was sent outside of thread. Attempted to send to thread_ts={event['ts']}. Unsending."
+        )
+        await client.chat_delete(channel=event["channel"], ts=msg_ts)
+        raise ThreadGoneError()
+    return msg
 
 
 async def on_message(event: Dict[str, Any], client: AsyncWebClient):

--- a/nephthys/utils/ticket_methods.py
+++ b/nephthys/utils/ticket_methods.py
@@ -9,6 +9,13 @@ from nephthys.database.tables import Ticket
 from nephthys.utils.env import env
 
 
+class ThreadGoneError(Exception):
+    """Raise when we try to end a message to that thread, but the thread no longer exists
+
+    This can happen when the top-level message is deleted.
+    """
+
+
 async def delete_message(channel_id: str, message_ts: str):
     """Deletes a Slack message, or does nothing if the message doesn't exist"""
     try:
@@ -30,16 +37,24 @@ async def reply_to_ticket(
     """Sends a user-facing message in the help thread and records it in the database"""
     channel = env.slack_help_channel
     thread_ts = ticket.msg_ts
-    msg = await client.chat_postMessage(
+    response = await client.chat_postMessage(
         channel=channel,
         text=text,
         thread_ts=thread_ts,
         blocks=[block.build() for block in blocks] if blocks else None,
     )
-    msg_ts = msg["ts"]
+    msg: dict = response["message"]  # type: ignore (assuming message exists)
+    msg_ts = msg.get("ts")
+    msg_thread_ts = msg.get("thread_ts")
     if not msg_ts:
-        logging.error(f"Bot message has no ts: {msg}")
-        return
+        raise ValueError(f"Bot message has no ts: {msg}")
+    if not msg_thread_ts:
+        # The thread probably got deleted while we were processing the event
+        logging.warning(
+            f"Reply to ticket was sent outside of thread. Attempted to send to thread_ts={thread_ts} for ticket_id={ticket.id}. Unsending."
+        )
+        await client.chat_delete(channel=channel, ts=msg_ts)
+        raise ThreadGoneError()
     bot_msg = BotMessage(ts=msg_ts, channel_id=channel, ticket=ticket.id)
     await bot_msg.save()
 


### PR DESCRIPTION
This should prevent the bot from sending messages to the channel in more situations than were checked before.

(well, technically it will send the message and then delete it right after because Slack Moment)

Context on Slack: https://hackclub.slack.com/archives/C0B1K0L1327/p1781601728531039