### PR TITLE
Remove mesage content from API endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,6 @@ Returns an array of ticket objects. Ticket objects look like this:
 interface Ticket {
   id: number
   title: string
-  description: string
   status: "OPEN" | "CLOSED" | "IN_PROGRESS"
   opened_by: User | null
   closed_by: User | null
@@ -113,6 +112,8 @@ interface User {
   username: string | null
 }
 ```
+
+Note that the `description` field was removed from the API on 16 June 2026 to comply with the [Hack Club Slack Scraping Policy](https://news.hackclub.com/news/scraping-use-policy/), as it contains message content. It may be exposed through an authenticated API in the future. For now, the `title` field can be used as a summarised alternative of the ticket content.
 
 ## `/api/ticket?id=<TICKET_ID>`
 

--- a/nephthys/api/ticket.py
+++ b/nephthys/api/ticket.py
@@ -20,13 +20,12 @@ def user_to_json(user: dict[str, Any]) -> dict | None:
     }
 
 
-def ticket_to_json(ticket: dict[str, Any]) -> dict:
+def ticket_to_json(ticket: dict[str, Any], include_description: bool = False) -> dict:
     """Converts a Ticket record (represented as a dict) to an API JSON format"""
     # I hate using dicts here because we get no type hinting :fear:
-    return {
+    json = {
         "id": ticket["id"],
         "title": ticket["title"],
-        "description": ticket["description"],
         "status": ticket["status"],
         "opened_by": user_to_json(ticket["openedById"]),
         "closed_by": user_to_json(ticket["closedById"]),
@@ -37,6 +36,9 @@ def ticket_to_json(ticket: dict[str, Any]) -> dict:
         "closed_at": ticket["closedAt"].isoformat() if ticket["closedAt"] else None,
         "message_ts": ticket["msgTs"],
     }
+    if include_description:
+        json["description"] = ticket["description"]
+    return json
 
 
 async def ticket_info(req: Request):


### PR DESCRIPTION
Removes the `description` field from `/api/tickets` and `/api/ticket` responses, as it contains Slack message content.

This is to comply with https://news.hackclub.com/news/scraping-use-policy/, which disallows message contents to be publicly accessible on the web. It may be exposed through an authenticated API in the future. For now, the `title` field can be used as a summarised alternative of the ticket content. 

### Breaking API change

The `description` field on /api/tickets and /api/ticket responses has been removed.
