### PR TITLE
Fix the loading.gif

### DIFF
--- a/nephthys/views/home/loading.py
+++ b/nephthys/views/home/loading.py
@@ -17,7 +17,7 @@ def get_loading_view(home_type: AppHomeView):
             },
             {
                 "type": "image",
-                "image_url": f"{env.base_url}/public/loading.gif",
+                "image_url": r"https://raw.githubusercontent.com/hackclub/nephthys/refs/heads/main/nephthys/public/loading.gif",
                 "alt_text": "Loading...",
             },
         ],


### PR DESCRIPTION
The loading.gif was not loading for any bots using Nephthys and was showing error while opening App Home. So I changed that to a static one.