### PR TITLE
More resilient app home views

### DIFF
--- a/nephthys/events/app_home_opened.py
+++ b/nephthys/events/app_home_opened.py
@@ -76,6 +76,7 @@ async def open_app_home(
         # Generate the view (this is when DB queries are made)
         user = await User.objects().where(User.slack_id == user_id).first()
         logging.info(f"Opening {home_type} for {user_id}")
+
         async with perf_timer(
             f"Rendering app home (type={home_type})",
             APP_HOME_RENDER_DURATION,
@@ -105,6 +106,11 @@ async def open_app_home(
 
         # Publish the view!
         await publish_view(client, user_id, view)
+
+        # Record the user's last-viewed page for future visits
+        if user:
+            user.app_home_last_view = home_type.value
+            await user.save()
 
     except Exception as e:
         logging.error(f"Error opening app home: {e}")

--- a/nephthys/events/app_home_opened.py
+++ b/nephthys/events/app_home_opened.py
@@ -127,6 +127,7 @@ async def open_app_home(
             f"`{err_type}` opening app home for <@{user_id}>",
             messages=[f"```{tb_str}```", f"cc <@{env.slack_maintainer_id}>"],
         )
+        await publish_view(client, user_id, view)
 
 
 async def publish_view(client: AsyncWebClient, user_id: str, view: dict[str, Any]):

--- a/nephthys/utils/slack.py
+++ b/nephthys/utils/slack.py
@@ -91,7 +91,6 @@ async def manage_home_switcher(ack: AsyncAck, body, client: AsyncWebClient):
     await ack()
     user_id = body["user"]["id"]
     action_id = body["actions"][0]["action_id"]
-    user = await User.objects().where(User.slack_id == user_id).first()
     try:
         view = AppHomeView(action_id)
     except ValueError:
@@ -101,11 +100,6 @@ async def manage_home_switcher(ack: AsyncAck, body, client: AsyncWebClient):
         return
 
     await open_app_home(view, client, user_id)
-    # Edge case: if the user viewing App Home isn't in the DB, they won't
-    # have their last view saved and restored.
-    if user:
-        user.app_home_last_view = view.value
-        await user.save()
 
 
 for view in AppHomeView:


### PR DESCRIPTION
This mitigates a failure case introduced in #214 where if you selected an App Home view that failed to render, you'd be softlocked in that bugged view forever.

### Changes

- Only record the last view after the view has successfully rendered and been published
- Actually publish the error view if a view render raises an exception
