### PR TITLE
Give credit to the last responder (not the resolver) on recently-active threads

### DIFF
--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -98,9 +98,9 @@ async def resolve(
 
     # Build the "ticket resolved!" message
     text = (
-        env.transcript.ticket_resolve.format(user_id=credit_user.slack_id)
+        env.transcript.ticket_resolve.format(user_id=resolving_user.slack_id)
         if not stale
-        else env.transcript.ticket_resolve_stale.format(user_id=credit_user.slack_id)
+        else env.transcript.ticket_resolve_stale.format(user_id=resolving_user.slack_id)
     )
     actions = Actions()
     if env.enable_feedback:

--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 from datetime import timedelta
+from datetime import UTC
 
 from blockkit import Actions
 from blockkit import Button
@@ -63,7 +64,7 @@ async def resolve(
         )
         return
 
-    now = datetime.now()
+    now = datetime.now(UTC)
 
     # If the last message in the thread is recent, credit goes to the last
     # helper who replied (ticket.assigned_to) rather than whoever clicked
@@ -125,6 +126,13 @@ async def resolve(
             text=text,
             blocks=[Section(text), actions],
         )
+        if resolving_user.helper and credit_user.slack_id != resolving_user.slack_id:
+            await client.chat_postEphemeral(
+                channel=env.slack_help_channel,
+                thread_ts=ts,
+                user=resolving_user.slack_id,
+                text=f"by the way! since this is still an active ticket, i've credited this resolve to <@{credit_user.slack_id}>",
+            )
     if add_reaction:
         await client.reactions_add(
             channel=env.slack_help_channel,

--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from datetime import timedelta
 
 from blockkit import Actions
 from blockkit import Button
@@ -16,6 +17,8 @@ from nephthys.utils.logging import send_heartbeat
 from nephthys.utils.permissions import can_resolve
 from nephthys.utils.ticket_methods import delete_message
 from nephthys.utils.ticket_methods import reply_to_ticket
+
+THREAD_CREDIT_CUTOFF = timedelta(hours=48)
 
 
 async def resolve(
@@ -60,19 +63,26 @@ async def resolve(
         )
         return
 
-    if not resolving_user.helper and ticket.assigned_to:
-        new_resolving_user = (
-            await User.objects().where(User.id == ticket.assigned_to.id).first()
-        )
-        if new_resolving_user:
-            resolving_user = new_resolving_user
-
     now = datetime.now()
+
+    # If the last message in the thread is recent, credit goes to the last
+    # helper who replied (ticket.assigned_to) rather than whoever clicked
+    # resolve. This prevents rewarding "stealing" active threads, while
+    # still rewarding closing stale, already-answered threads.
+    credit_user = resolving_user
+    if (
+        ticket.assigned_to
+        and ticket.last_msg_at is not None
+        and (now - ticket.last_msg_at) <= THREAD_CREDIT_CUTOFF
+    ):
+        credit_user = ticket.assigned_to
+    elif not resolving_user.helper and ticket.assigned_to:
+        credit_user = ticket.assigned_to
 
     await Ticket.update(
         {
             Ticket.status: TicketStatus.CLOSED,
-            Ticket.closed_by: resolving_user.id,
+            Ticket.closed_by: credit_user.id,
             Ticket.closed_at: now,
         }
     ).where(Ticket.msg_ts == ts)
@@ -87,9 +97,9 @@ async def resolve(
 
     # Build the "ticket resolved!" message
     text = (
-        env.transcript.ticket_resolve.format(user_id=resolver)
+        env.transcript.ticket_resolve.format(user_id=credit_user.slack_id)
         if not stale
-        else env.transcript.ticket_resolve_stale.format(user_id=resolver)
+        else env.transcript.ticket_resolve_stale.format(user_id=credit_user.slack_id)
     )
     actions = Actions()
     if env.enable_feedback:
@@ -142,4 +152,6 @@ async def resolve(
             channel_id=env.slack_ticket_channel, message_ts=tkt.ticket_ts
         )
 
-    logging.info(f"Resolved ticket ts={ts} resolving_user={resolving_user.slack_id}")
+    logging.info(
+        f"Resolved ticket ts={ts} by slack_id={resolving_user.slack_id} credit_to={credit_user.slack_id}"
+    )


### PR DESCRIPTION
### Full description

Ideally I want anyone to be able to resolve tickets if they're answered without it being unfair, so I'm thinking of changing how the bot counts who resolved each ticket:

- If the last message in thread was over 48h ago, the old behaviour applies (if you resolve a ticket the credit will go to you)
- If last message is newer than 48h, the last helper to say something in the thread will get the credit, even if another helper resolves it

Hopefully that'll mean if you see an answered ticket, you can mark it as resolved without worrying about "stealing" the ticket

[Source: this Slack thread](https://hackclub.slack.com/archives/C0B1K0L1327/p1781613938128959)

### Screenshot

<img width="443" height="340" alt="dms_capture_1783897035844" src="https://github.com/user-attachments/assets/e9723fef-8be8-484b-897b-5947bd5f8fea" />
