### PR TITLE
Fix "i've credited this resolve to <@None>"

### DIFF
--- a/nephthys/actions/resolve.py
+++ b/nephthys/actions/resolve.py
@@ -72,12 +72,12 @@ async def resolve(
     # still rewarding closing stale, already-answered threads.
     credit_user = resolving_user
     if (
-        ticket.assigned_to
+        ticket.assigned_to.id
         and ticket.last_msg_at is not None
         and (now - ticket.last_msg_at) <= THREAD_CREDIT_CUTOFF
     ):
         credit_user = ticket.assigned_to
-    elif not resolving_user.helper and ticket.assigned_to:
+    elif not resolving_user.helper and ticket.assigned_to.id:
         credit_user = ticket.assigned_to
 
     await Ticket.update(


### PR DESCRIPTION
This should not happen anymore:

<img width="514" height="459" alt="i've credited this resolve to <@None>" src="https://github.com/user-attachments/assets/1bf9f034-231e-4018-b9aa-f870e88f0478" />

Bug was introduced in #243

Causal factors: using Command Code to write the offending code (perhaps, idk), Piccolo being strange and behaving in unexpected ways, and the fact that I always send a message when testing resolving tickets (so I don't catch the case where no message has been sent).