### PR TITLE
Add Stale tickets Macro an alternative to Auto Close Stale tickets

### DIFF
--- a/nephthys/macros/__init__.py
+++ b/nephthys/macros/__init__.py
@@ -14,6 +14,7 @@ from nephthys.macros.reopen import Reopen
 from nephthys.macros.resolve import Resolve
 from nephthys.macros.shipcertqueue import ShipCertQueue
 from nephthys.macros.shipwrights import Shipwrights
+from nephthys.macros.stale import Stale
 from nephthys.macros.team_tag import TeamTag
 from nephthys.macros.thread import Thread
 from nephthys.macros.trigger_daily_stats import DailyStats
@@ -42,6 +43,7 @@ macro_list: list[type[Macro]] = [
     VoteQueue,
     MaxTokens,
     NoMoney,
+    Stale,
 ]
 
 macros = [macro() for macro in macro_list]

--- a/nephthys/macros/stale.py
+++ b/nephthys/macros/stale.py
@@ -1,0 +1,11 @@
+from nephthys.macros.types import ReplyMacro
+from nephthys.utils.env import env
+
+
+class Stale(ReplyMacro):
+    """
+    A simple macro telling people that the ticket is stale and resolving it.
+    """
+
+    name = "stale"
+    message = env.transcript.stale_tickets_macro

--- a/nephthys/transcripts/transcript.py
+++ b/nephthys/transcripts/transcript.py
@@ -129,6 +129,11 @@ class Transcript(BaseModel):
         description="Message for credits ran out",
     )
 
+    stale_tickets_macro: str | None = Field(
+        default="Hey, (user)!\nAs you didn't respond, this thread will be marked as resolved.\n\nPlease make a new thread in this channel if you have more questions.",
+        description="Message for closing stale tickets and resolving it(better than autoclose)",
+    )
+
     not_allowed_channel: str = Field(
         default="", description="Message for unauthorized channel access"
     )

--- a/nephthys/transcripts/transcript.py
+++ b/nephthys/transcripts/transcript.py
@@ -130,8 +130,8 @@ class Transcript(BaseModel):
     )
 
     stale_tickets_macro: str = Field(
-        default="Hey, (user)!\nAs you didn't respond, this thread will be marked as resolved.\n\nPlease make a new thread in this channel if you have more questions.",
-        description="Message for closing stale tickets and resolving it(better than autoclose)",
+        default="Hey, (user)!It seems like this ticket has been inactive for some days so I'll be closing it.\nIf your question wasn't answered, please feel free to make a new one. Thanks!"",
+        description="Message for closing stale tickets",
     )
 
     not_allowed_channel: str = Field(

--- a/nephthys/transcripts/transcript.py
+++ b/nephthys/transcripts/transcript.py
@@ -130,7 +130,7 @@ class Transcript(BaseModel):
     )
 
     stale_tickets_macro: str = Field(
-        default="Hey, (user)!It seems like this ticket has been inactive for some days so I'll be closing it.\nIf your question wasn't answered, please feel free to make a new one. Thanks!"",
+        default="Hey, (user)!It seems like this ticket has been inactive for some days so I'll be closing it.\nIf your question wasn't answered, please feel free to make a new one. Thanks!",
         description="Message for closing stale tickets",
     )
 

--- a/nephthys/transcripts/transcript.py
+++ b/nephthys/transcripts/transcript.py
@@ -130,7 +130,7 @@ class Transcript(BaseModel):
     )
 
     stale_tickets_macro: str = Field(
-        default="Hey, (user)!It seems like this ticket has been inactive for some days so I'll be closing it.\nIf your question wasn't answered, please feel free to make a new one. Thanks!",
+        default="Hey, (user)! It seems like this ticket has been inactive for some days so I'll be closing it.\nIf your question wasn't answered, please feel free to make a new one. Thanks!",
         description="Message for closing stale tickets",
     )
 

--- a/nephthys/transcripts/transcript.py
+++ b/nephthys/transcripts/transcript.py
@@ -129,7 +129,7 @@ class Transcript(BaseModel):
         description="Message for credits ran out",
     )
 
-    stale_tickets_macro: str | None = Field(
+    stale_tickets_macro: str = Field(
         default="Hey, (user)!\nAs you didn't respond, this thread will be marked as resolved.\n\nPlease make a new thread in this channel if you have more questions.",
         description="Message for closing stale tickets and resolving it(better than autoclose)",
     )


### PR DESCRIPTION
Add Stale tickets Macro an alternative to Auto Close Stale tickets
This can be used by helpers to provide knowledge to op that the ticket is stale and the helper closed it.